### PR TITLE
- perform documents.getSearch only when search dialog is open,

### DIFF
--- a/components/search-command.tsx
+++ b/components/search-command.tsx
@@ -12,12 +12,14 @@ import { File } from "lucide-react";
 export const SearchCommand = () => {
     const {user} = useUser();
     const router = useRouter();
-    const documents = useQuery(api.documents.getSearch);
+    //const documents = useQuery(api.documents.getSearch);
     const [isMounted,setIsMounted] = useState(false)
 
     const toggle = useSearch((store) => store.toggle)
     const isOpen = useSearch((store) => store.isOpen)
     const onClose = useSearch((store) => store.onClose)
+
+    const documents = useQuery(api.documents.getSearch, {enabled: isOpen});
 
     useEffect(()=>{
         setIsMounted(true);

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -207,7 +207,11 @@ export const remove = mutation({
 });
 
 export const getSearch = query({
-  handler: async (ctx) => {
+  args: { enabled: v.boolean() },
+  handler: async (ctx, args) => {
+
+    if (args.enabled) return [];
+
     const identity = await ctx.auth.getUserIdentity();
 
     if (!identity) {

--- a/convex/documents.ts
+++ b/convex/documents.ts
@@ -210,7 +210,7 @@ export const getSearch = query({
   args: { enabled: v.boolean() },
   handler: async (ctx, args) => {
 
-    if (args.enabled) return [];
+    if (!args.enabled) return [];
 
     const identity = await ctx.auth.getUserIdentity();
 


### PR DESCRIPTION
this dramatically reduces Convex db bandwidth usage.